### PR TITLE
Index initial data set as compact JSON-LD in Elasticsearch

### DIFF
--- a/oer-data/pom.xml
+++ b/oer-data/pom.xml
@@ -25,10 +25,16 @@
 	</repositories>
 	<dependencies>
 		<dependency>
-		    <groupId>org.culturegraph</groupId>
-		    <artifactId>metafacture-core</artifactId>
-		    <version>1.2.0</version>
-    </dependency>
+			<groupId>org.culturegraph</groupId>
+			<artifactId>metafacture-core</artifactId>
+			<version>1.2.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-core</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
     <dependency>
       <groupId>org.lobid</groupId>
       <artifactId>lodmill-rd</artifactId>

--- a/oer-data/src/main/java/org/hbz/oerworldmap/NtToEs.java
+++ b/oer-data/src/main/java/org/hbz/oerworldmap/NtToEs.java
@@ -2,11 +2,21 @@
 
 package org.hbz.oerworldmap;
 
-import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.UUID;
 
 import org.apache.jena.riot.Lang;
@@ -19,8 +29,14 @@ import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 
+import com.github.jsonldjava.core.JsonLdError;
+import com.github.jsonldjava.core.JsonLdOptions;
+import com.github.jsonldjava.core.JsonLdProcessor;
+import com.github.jsonldjava.utils.JSONUtils;
+import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
 import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.rdf.model.ModelFactory;
 
 /**
  * Convert N-Triples to JSON-LD and index it in Elasticsearch.
@@ -29,11 +45,10 @@ import com.hp.hpl.jena.rdf.model.Model;
  */
 public class NtToEs {
 
-	static final String DATA = "src/main/resources/ocwc/ocw-example.nt";
 	static final String CONFIG = "src/main/resources/index-config.json";
+	static final String CONTEXT = "src/main/resources/context.json";
 	static final String TYPE = "oer-type";
 	static final String INDEX = "oer-index";
-	static final String ID = UUID.nameUUIDFromBytes(DATA.getBytes()).toString();
 	static final Client CLIENT = new TransportClient(ImmutableSettings
 			.settingsBuilder().put("cluster.name", "quaoar").build())
 			.addTransportAddress(new InetSocketTransportAddress(
@@ -41,30 +56,91 @@ public class NtToEs {
 
 	public static void main(String[] args) throws ElasticSearchException,
 			FileNotFoundException, IOException {
+		if (args.length != 1) {
+			System.err
+					.println("Pass a single arg: the root directory to crawl. "
+							+ "Will recursively gather all content from *.nt "
+							+ "files with identical names, convert these to "
+							+ "compact JSON-LD and index it in ES.");
+			System.exit(-1);
+		}
+		TripleCrawler crawler = new TripleCrawler();
+		Files.walkFileTree(Paths.get(args[0]), crawler);
 		createIndex(CharStreams.toString(new FileReader(CONFIG)));
-		indexData(ntToJsonLd(DATA));
+		process(crawler.data);
 	}
 
-	private static void indexData(String jsonLdString) {
-		IndexResponse r = CLIENT.prepareIndex(INDEX, TYPE, ID)
-				.setSource(jsonLdString).execute().actionGet();
-		System.out.printf(
-				"Indexed into index %s, type %s, id %s, version %s\n",
-				r.getIndex(), r.getType(), r.getId(), r.getVersion());
+	private static final class TripleCrawler extends SimpleFileVisitor<Path> {
+		Map<String, StringBuilder> data = new HashMap<String, StringBuilder>();
+
+		@Override
+		public FileVisitResult visitFile(Path path, BasicFileAttributes attr)
+				throws IOException {
+			if (path.toString().endsWith(".nt")) {
+				String content = com.google.common.io.Files.toString(
+						path.toFile(), Charsets.UTF_8);
+				collectContent(path.getFileName().toString(), content);
+			}
+			return FileVisitResult.CONTINUE;
+		}
+
+		private void collectContent(String name, String content) {
+			if (!data.containsKey(name))
+				data.put(name, new StringBuilder());
+			data.get(name).append("\n").append(content);
+		}
 	}
 
-	private static void createIndex(String indexConfig) {
+	private static void createIndex(String config) {
 		IndicesAdminClient admin = CLIENT.admin().indices();
 		if (!admin.prepareExists(INDEX).execute().actionGet().isExists())
-			admin.prepareCreate(INDEX).setSource(indexConfig).execute()
-					.actionGet();
+			admin.prepareCreate(INDEX).setSource(config).execute().actionGet();
 	}
 
-	private static String ntToJsonLd(String ntFile) {
-		Model model = RDFDataMgr.loadModel(new File(ntFile).toURI().toString());
+	private static void process(Map<String, StringBuilder> map) {
+		for (Entry<String, StringBuilder> e : map.entrySet()) {
+			try {
+				indexData(uuid(e.getKey()), ntToJsonLd(e.getValue().toString()));
+			} catch (Exception x) {
+				System.err.printf("Could not process file %s due to %s\n",
+						e.getKey(), x.getMessage());
+				x.printStackTrace();
+			}
+		}
+	}
+
+	private static void indexData(String id, String data) {
+		IndexResponse r = CLIENT.prepareIndex(INDEX, TYPE, id).setSource(data)
+				.execute().actionGet();
+		System.out.printf(
+				"Indexed into index %s, type %s, id %s, version %s: %s\n",
+				r.getIndex(), r.getType(), r.getId(), r.getVersion(), data);
+	}
+
+	private static String uuid(String id) {
+		return UUID.nameUUIDFromBytes(id.getBytes()).toString();
+	}
+
+	private static String ntToJsonLd(String data) {
+		Model model = ModelFactory.createDefaultModel();
+		model.read(new StringReader(data), null, "N-Triples");
 		StringWriter stringWriter = new StringWriter();
 		RDFDataMgr.write(stringWriter, model, Lang.JSONLD);
-		return stringWriter.toString();
+		return compact(stringWriter.toString());
 	}
 
+	private static String compact(String json) {
+		try {
+			Object contextJson = JSONUtils.fromInputStream(new FileInputStream(
+					CONTEXT));
+			JsonLdOptions options = new JsonLdOptions();
+			options.setCompactArrays(false); // ES needs consistent data
+			Map<String, Object> compact = JsonLdProcessor.compact(
+					JSONUtils.fromString(json), contextJson, options);
+			return JSONUtils.toString(compact);
+		} catch (IOException | JsonLdError e) {
+			throw new IllegalStateException("Could not compact JSON-LD: \n"
+					+ json, e);
+		}
+	}
 }

--- a/oer-data/src/main/resources/context.json
+++ b/oer-data/src/main/resources/context.json
@@ -1,0 +1,31 @@
+{
+    "description" : "http://schema.org/description",
+    "descriptionLink" : {
+      "@id" : "http://schema.org/description",
+      "@type" : "@id"
+    },
+    "geo" : {
+      "@id" : "http://schema.org/geo",
+      "@type" : "@id"
+    },
+    "hasMembership" : {
+      "@id" : "http://www.w3.org/ns/org#hasMembership",
+      "@type" : "@id"
+    },
+    "identifier" : "http://purl.org/dc/elements/1.1/identifier",
+    "latitude" : "http://schema.org/latitude",
+    "logo" : {
+      "@id" : "http://schema.org/logo",
+      "@type" : "@id"
+    },
+    "longitude" : "http://schema.org/longitude",
+    "name" : "http://schema.org/name",
+    "providesService" : {
+      "@id" : "http://schema.org/providesService",
+      "@type" : "@id"
+    },
+    "url" : {
+      "@id" : "http://schema.org/url",
+      "@type" : "@id"
+    }
+  }

--- a/oer-data/src/main/resources/index-config.json
+++ b/oer-data/src/main/resources/index-config.json
@@ -11,8 +11,14 @@
   },
   "mappings":{
     "oer-type":{
+      "date_detection":false,
+      "numeric_detection":false,
       "properties":{
         "@graph.@type":{
+          "type":"string",
+          "index":"not_analyzed"
+        },
+        "@graph.@id":{
           "type":"string",
           "index":"not_analyzed"
         }


### PR DESCRIPTION
See #10

Crawl local N-Triples created with the Metafacture transformation, create compact JSON-LD with non-compact arrays (Elasticsearch requires consistent value types for a given key), index the result.

Deployed to staging: http://staging.api.lobid.org/oer

Sample query: http://staging.api.lobid.org/oer?q=*&t=http://schema.org/CollegeOrUniversity

<!---
@huboard:{"order":11.0,"custom_state":""}
-->
