### PR TITLE
Add `location` parameter to filter results in a given polygon

### DIFF
--- a/oer-api/app/controllers/oer/Application.java
+++ b/oer-api/app/controllers/oer/Application.java
@@ -2,10 +2,12 @@
 
 package controllers.oer;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.jena.riot.Lang;
 import org.elasticsearch.action.get.GetResponse;
@@ -18,6 +20,9 @@ import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.FilterBuilder;
+import org.elasticsearch.index.query.FilterBuilders;
+import org.elasticsearch.index.query.GeoPolygonFilterBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -32,6 +37,8 @@ import play.mvc.Http.RawBuffer;
 import play.mvc.Result;
 import views.html.oer_index;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.github.jsonldjava.utils.JSONUtils;
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.io.BaseEncoding;
@@ -43,10 +50,10 @@ public class Application extends Controller {
 	private static final String USER_TYPE = "users";
 
 	final static Client productionClient = new TransportClient(
-			ImmutableSettings.settingsBuilder().put("cluster.name", "quaoar")
-					.build())
+			ImmutableSettings.settingsBuilder()
+					.put("cluster.name", "quaoar-test").build())
 			.addTransportAddress(new InetSocketTransportAddress(
-					"193.30.112.170", 9300));
+					"193.30.112.171", 9300));
 	static Client client = productionClient;
 
 	/**
@@ -100,7 +107,7 @@ public class Application extends Controller {
 				.setSource("user", user, "pass", pass).execute().actionGet()));
 	}
 
-	public static Result query(String q, String t) {
+	public static Result query(String q, String t, String location) {
 		if (q.trim().isEmpty() && t.trim().isEmpty())
 			return ok(oer_index.render(Arrays.asList(
 					// @formatter:off@
@@ -108,9 +115,10 @@ public class Application extends Controller {
 					"/oer?q=*&t=http://schema.org/CollegeOrUniversity",
 					"/oer?q=Africa&t=http://schema.org/CollegeOrUniversity",
 					"/oer?q=Africa&t=http://schema.org/CollegeOrUniversity,"
-					+ "http://www.w3.org/ns/org#OrganizationalCollaboration")));
+					+ "http://www.w3.org/ns/org#OrganizationalCollaboration",
+					"/oer?q=*&location=40.8,-86.6+40.8,-88.6+42.8,-88.6+42.8,-86.6")));
 					// @formatter:on@
-		return processQuery(q, t);
+		return processQuery(q, t, location);
 	}
 
 	public static Result get(String id) {
@@ -175,8 +183,8 @@ public class Application extends Controller {
 
 	private static boolean authorized(String authHeader) {
 		String[] userAndPass = userAndPass(authHeader);
-		SearchResponse search = search(QueryBuilders.idsQuery(USER_TYPE).ids(
-				userAndPass[0]));
+		SearchResponse search = search(
+				QueryBuilders.idsQuery(USER_TYPE).ids(userAndPass[0]), "");
 		return search.getHits().getTotalHits() == 1
 				&& BCrypt.checkpw(userAndPass[1], (String) search.getHits()
 						.getAt(0).getSource().get("pass"));
@@ -193,17 +201,33 @@ public class Application extends Controller {
 		return new String[] { "unauthorized", "" };
 	}
 
-	private static Result processQuery(String q, String t) {
+	private static Result processQuery(String q, String t, String location) {
 		BoolQueryBuilder query = QueryBuilders.boolQuery().must(
 				QueryBuilders.queryString(q).field("_all"));
 		if (!t.trim().isEmpty())
 			query = query.must(typeQuery(t));
-		SearchResponse response = search(query);
+		SearchResponse response = search(query, location);
 		List<String> hits = new ArrayList<String>();
 		for (SearchHit hit : response.getHits())
-			hits.add(hit.getSourceAsString());
+			hits.add(withoutGeo(hit.getSourceAsString()));
 		String jsonString = "[" + Joiner.on(",").join(hits) + "]";
 		return ok(Json.parse(jsonString));
+	}
+
+	private static String withoutGeo(String sourceAsString) {
+		try {
+			// JSON-LD compact, always an object (resulting in a map)
+			@SuppressWarnings("unchecked")
+			Map<String, Object> json = (Map<String, Object>) JSONUtils
+					.fromString(sourceAsString);
+			json.remove("location");
+			return JSONUtils.toString(json);
+		} catch (JsonParseException e) {
+			e.printStackTrace();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return sourceAsString;
 	}
 
 	private static BoolQueryBuilder typeQuery(String t) {
@@ -215,13 +239,30 @@ public class Application extends Controller {
 		return query;
 	}
 
-	private static SearchResponse search(final QueryBuilder queryBuilder) {
+	private static SearchResponse search(final QueryBuilder queryBuilder,
+			String location) {
 		SearchRequestBuilder requestBuilder = client.prepareSearch(INDEX)
 				.setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
 				.setQuery(queryBuilder);
-		SearchResponse response = requestBuilder.setFrom(0).setSize(50)
+		if (!location.trim().isEmpty())
+			requestBuilder = requestBuilder.setFilter(locationFilter(location));
+		Logger.debug("Request:\n" + requestBuilder);
+		SearchResponse response = requestBuilder.setFrom(0).setSize(500)
 				.setExplain(false).execute().actionGet();
+		Logger.debug("Response:\n" + response);
 		return response;
+	}
+
+	private static FilterBuilder locationFilter(String location) {
+		GeoPolygonFilterBuilder filter = FilterBuilders
+				.geoPolygonFilter("oer-type.location");
+		String[] points = location.split(" ");
+		for (String point : points) {
+			String[] latLon = point.split(",");
+			filter = filter.addPoint(Double.parseDouble(latLon[0].trim()),
+					Double.parseDouble(latLon[1].trim()));
+		}
+		return filter;
 	}
 
 	private static String responseInfo(IndexResponse r) {

--- a/oer-api/app/views/oer_index.scala.html
+++ b/oer-api/app/views/oer_index.scala.html
@@ -17,6 +17,8 @@
         <dd>Filter results by the <code>@@type</code> field (pass multiple, comma-separated values for OR logic).</dd>
         <dt><code>location</code> (optional)</dt>
         <dd>Filter results by their location (pass multiple, space-separated "lon,lat" pairs for a <a href="http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-geo-polygon-filter.html#_lat_lon_as_string_5">polygon filter</a>).</dd>
+        <dt><code>callback</code> (optional)</dt>
+        <dd>For JSONP requests.</dd>
         <dt>Samples<dt>
         <dd>
         @for(query <- queries) { <a href="@query">@query</a><br/> }

--- a/oer-api/app/views/oer_index.scala.html
+++ b/oer-api/app/views/oer_index.scala.html
@@ -15,6 +15,8 @@
         <dd>Query over all fields, supports <a href="http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax"> elasticsearch query string syntax</a>.</dd>
         <dt><code>t</code> (optional)</dt>
         <dd>Filter results by the <code>@@type</code> field (pass multiple, comma-separated values for OR logic).</dd>
+        <dt><code>location</code> (optional)</dt>
+        <dd>Filter results by their location (pass multiple, space-separated "lon,lat" pairs for a <a href="http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-geo-polygon-filter.html#_lat_lon_as_string_5">polygon filter</a>).</dd>
         <dt>Samples<dt>
         <dd>
         @for(query <- queries) { <a href="@query">@query</a><br/> }

--- a/oer-api/build.sbt
+++ b/oer-api/build.sbt
@@ -6,7 +6,7 @@ libraryDependencies ++= Seq(
   cache,
   "org.elasticsearch" % "elasticsearch" % "0.90.7" withSources(),
   "org.mindrot" % "jbcrypt" % "0.3m" withSources(),
-  "org.apache.jena" % "jena-arq" % "2.11.2-SNAPSHOT" withSources()
+  "org.apache.jena" % "jena-arq" % "2.11.2-SNAPSHOT"
 )
 
 resolvers += "jena-dev" at "https://repository.apache.org/content/repositories/snapshots"

--- a/oer-api/conf/oer.routes
+++ b/oer-api/conf/oer.routes
@@ -3,7 +3,7 @@
 # ~~~~
 
 # API query route
-GET     /oer                        controllers.oer.Application.query(q?="",t?="")
+GET     /oer                        controllers.oer.Application.query(q?="",t?="",location?="")
 GET     /oer/:id                    controllers.oer.Application.get(id)
 PUT     /oer/:id                    controllers.oer.Application.put(id)
 

--- a/oer-api/public/data/index-config.json
+++ b/oer-api/public/data/index-config.json
@@ -21,6 +21,9 @@
         "@graph.@id":{
           "type":"string",
           "index":"not_analyzed"
+        },
+        "location" : {
+          "type" : "geo_point"
         }
       }
     }

--- a/oer-api/test/test/ApplicationTest.java
+++ b/oer-api/test/test/ApplicationTest.java
@@ -42,7 +42,7 @@ public class ApplicationTest extends IndexTestsHarness {
 	@Test
 	public void queryAll() {
 		Result result = callAction(
-				controllers.oer.routes.ref.Application.query("*", ""),
+				controllers.oer.routes.ref.Application.query("*", "", ""),
 				fakeRequest());
 		assertThat(status(result)).isEqualTo(OK);
 		assertThat(Json.parse(contentAsString(result)).size()).isEqualTo(3);
@@ -52,7 +52,7 @@ public class ApplicationTest extends IndexTestsHarness {
 	public void queryType0() {
 		Result result = callAction(
 				controllers.oer.routes.ref.Application.query("*",
-						"http://schema.org/CollegeOrUniversityTest0"),
+						"http://schema.org/CollegeOrUniversityTest0", ""),
 				fakeRequest());
 		assertThat(status(result)).isEqualTo(OK);
 		assertThat(Json.parse(contentAsString(result)).size()).isEqualTo(0);
@@ -62,7 +62,7 @@ public class ApplicationTest extends IndexTestsHarness {
 	public void queryType1() {
 		Result result = callAction(
 				controllers.oer.routes.ref.Application.query("*",
-						"http://schema.org/CollegeOrUniversityTest1"),
+						"http://schema.org/CollegeOrUniversityTest1", ""),
 				fakeRequest());
 		assertThat(status(result)).isEqualTo(OK);
 		assertThat(Json.parse(contentAsString(result)).size()).isEqualTo(1);
@@ -73,10 +73,20 @@ public class ApplicationTest extends IndexTestsHarness {
 		Result result = callAction(
 				controllers.oer.routes.ref.Application.query("*",
 						"http://schema.org/CollegeOrUniversityTest1,"
-								+ "http://schema.org/CollegeOrUniversityTest2"),
-				fakeRequest());
+								+ "http://schema.org/CollegeOrUniversityTest2",
+						""), fakeRequest());
 		assertThat(status(result)).isEqualTo(OK);
 		assertThat(Json.parse(contentAsString(result)).size()).isEqualTo(2);
+	}
+
+	@Test
+	public void queryAllFilterLocation() {
+		Result result = callAction(
+				controllers.oer.routes.ref.Application.query("*", "",
+						"40.8,-86.6 40.8,-88.6 42.8,-88.6 42.8,-86.6"),
+				fakeRequest());
+		assertThat(status(result)).isEqualTo(OK);
+		assertThat(Json.parse(contentAsString(result)).size()).isEqualTo(1);
 	}
 
 	@Test


### PR DESCRIPTION
See #34.

The required field is created internally and removed before serving (see #33).

Deployed to staging: http://staging.api.lobid.org/oer?q=*&location=40.8,-86.6+40.8,-88.6+42.8,-88.6+42.8,-86.6

This uses spaces (you can use `+` in the request) as the point delimiters instead of the semicolons suggested in #34 since semicolons have a reserved meaning as an optional query parameter separator: http://www.w3.org/TR/1999/REC-html401-19991224/appendix/notes.html#h-B.2.2

Assigning to @literarymachine for review.

<!---
@huboard:{"order":0.13671875,"custom_state":""}
-->
