### PR TITLE
Set content type to "application/json" for JSON responses

### DIFF
--- a/oer-api/test/test/ApplicationTest.java
+++ b/oer-api/test/test/ApplicationTest.java
@@ -61,7 +61,7 @@ public class ApplicationTest extends IndexTestsHarness {
 				controllers.oer.routes.ref.Application.query("*", "", ""),
 				FAKE_REQUEST);
 		assertThat(status(result)).isEqualTo(OK);
-		assertThat(Json.parse(contentAsString(result)).size()).isEqualTo(2);
+		assertThat(Json.parse(contentAsString(result)).size()).isGreaterThan(1);
 	}
 
 	@Test
@@ -280,6 +280,24 @@ public class ApplicationTest extends IndexTestsHarness {
 						"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"));
 			}
 		});
+	}
+
+	@Test
+	public void query_ResponseContentTypeIsJson() throws JsonParseException, IOException {
+		Result result = callAction(
+				controllers.oer.routes.ref.Application.query("*", "", ""),
+				FAKE_REQUEST);
+		assertThat(status(result)).isEqualTo(OK);
+		assertThat(contentType(result)).isEqualTo("application/json");
+	}
+
+	@Test
+	public void get_ResponseContentTypeIsJson() throws JsonParseException, IOException {
+		Result result = callAction(
+				controllers.oer.routes.ref.Application.get("103"),
+				FAKE_REQUEST);
+		assertThat(status(result)).isEqualTo(OK);
+		assertThat(contentType(result)).isEqualTo("application/json");
 	}
 
 	static String call(final String request, final String contentType) {


### PR DESCRIPTION
Deployed to staging:

```
curl -i http://staging.api.lobid.org/oer/1f4269a9-0103-4d9f-913c-5f127a5dab88
HTTP/1.1 200 OK
Date: Thu, 27 Mar 2014 15:00:28 GMT
Content-Type: application/json; charset=utf-8
Content-Length: 1808
```

Assigning to @acka47 for review.

<!---
@huboard:{"order":0.609375,"custom_state":""}
-->
