### PR TITLE
Move data transformation code from tests to a Transform class

### DIFF
--- a/oer-api/app/controllers/oer/NtToEs.java
+++ b/oer-api/app/controllers/oer/NtToEs.java
@@ -17,6 +17,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -58,15 +59,17 @@ public class NtToEs {
 	public static void main(String... args) throws ElasticSearchException,
 			FileNotFoundException, IOException {
 		if (args.length != 1 && args.length != 2) {
-			System.err.println("Pass the root directory to crawl. "
+			System.out.println("Pass the root directory to crawl. "
 					+ "Will recursively gather all content from *.nt "
 					+ "files with identical names, convert these to "
-					+ "compact JSON-LD and index it in ES."
-					+ "If a second argument is passed it is processed"
-					+ "as a TSV file that maps file names (w/o"
-					+ "extensions) to IDs to be used for ES. Else the"
+					+ "compact JSON-LD and index it in ES. "
+					+ "If a second argument is passed it is processed "
+					+ "as a TSV file that maps file names (w/o "
+					+ "extensions) to IDs to be used for ES. Else the "
 					+ "file names are used (w/o extensions) are used.");
-			System.exit(-1);
+			args = new String[] { "../oer-data/tmp/ocwc",
+					"../oer-data/src/main/resources/internalId2uuid.tsv" };
+			System.out.println("Using defaults: " + Arrays.asList(args));
 		}
 		TripleCrawler crawler = new TripleCrawler();
 		Files.walkFileTree(Paths.get(args[0]), crawler);

--- a/oer-data/.gitignore
+++ b/oer-data/.gitignore
@@ -1,3 +1,4 @@
 target/
 *.log
 tmp/
+tmp.stats.csv

--- a/oer-data/src/main/java/org/hbz/oerworldmap/Transform.java
+++ b/oer-data/src/main/java/org/hbz/oerworldmap/Transform.java
@@ -1,0 +1,135 @@
+package org.hbz.oerworldmap;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.apache.commons.io.FileUtils;
+import org.culturegraph.mf.morph.Metamorph;
+import org.culturegraph.mf.stream.converter.LiteralExtractor;
+import org.culturegraph.mf.stream.pipe.StreamTee;
+import org.culturegraph.mf.stream.source.DirReader;
+import org.culturegraph.mf.stream.source.FileOpener;
+import org.culturegraph.mf.stream.source.HttpOpener;
+import org.lobid.lodmill.PipeEncodeTriples;
+import org.lobid.lodmill.RdfModelFileWriter;
+import org.lobid.lodmill.Stats;
+import org.lobid.lodmill.Triples2RdfModel;
+
+import com.google.common.io.Files;
+
+/**
+ * Run as Java application to transform the full data. <br/>
+ * Static methods are also used by the tests.
+ */
+public class Transform {
+
+	private static final String GEO_LIST = "geoList";
+	private static final String ORGANIZATION_ID = "organizationId";
+	private static final String CONSORTIUM_MEMBERS = "consortiumMembers";
+	private static final String OCWC_PATH = "ocwc/";
+	private static final String TARGET_PATH = "tmp/";
+
+	public static void main(String[] args) throws URISyntaxException,
+			IOException {
+		FileUtils.deleteQuietly(new File(TARGET_PATH));
+		dataInDirectory(TARGET_PATH, OCWC_PATH + CONSORTIUM_MEMBERS);
+		dataInDirectory(TARGET_PATH, OCWC_PATH + ORGANIZATION_ID);
+		dataInDirectory(TARGET_PATH, OCWC_PATH + GEO_LIST);
+		geoWithHttpLookup("ocwc/geoList", "ocwc/geo", "tmp/");
+		Files.copy(new File(
+				"doc/scripts/additionalDataOcwcItself.ntriple.template"),
+				new File(TARGET_PATH + OCWC_PATH, "ocwc.nt"));
+	}
+
+	static void dataInDirectory(String targetPath, final String pathToDirectory)
+			throws URISyntaxException {
+		final DirReader dirReader = new DirReader();
+		final FileOpener opener = new FileOpener();
+		final JsonDecoder jsonDecoder = new JsonDecoder();
+		final Metamorph morph = new Metamorph(Thread.currentThread()
+				.getContextClassLoader()
+				.getResource("morph-ocwConsortiumMembers-to-rdf.xml").getFile());
+		final PipeEncodeTriples encoder = new PipeEncodeTriples();
+		encoder.setStoreUrnAsUri("true");
+		final Triples2RdfModel triple2model = new Triples2RdfModel();
+		triple2model.setInput("N-TRIPLE");
+		final RdfModelFileWriter writer = createOerWriter(targetPath
+				+ pathToDirectory);
+		final StreamTee streamTee = new StreamTee();
+		final Stats stats = new Stats();
+		streamTee.addReceiver(stats);
+		streamTee.addReceiver(encoder);
+		encoder.setReceiver(triple2model).setReceiver(writer);
+		opener.setReceiver(jsonDecoder);
+		jsonDecoder.setReceiver(morph).setReceiver(streamTee);
+		dirReader.setReceiver(opener);
+		dirReader.process((new File(Thread.currentThread()
+				.getContextClassLoader().getResource(pathToDirectory).toURI()))
+				.getAbsolutePath());
+		opener.closeStream();
+
+	}
+
+	private static RdfModelFileWriter createOerWriter(final String PATH) {
+		final RdfModelFileWriter writer = new RdfModelFileWriter();
+		writer.setProperty("http://purl.org/dc/elements/1.1/identifier");
+		writer.setEndIndex(1);
+		writer.setStartIndex(0);
+		writer.setFileSuffix("nt");
+		writer.setSerialization("N-TRIPLE");
+		writer.setTarget(PATH);
+		return writer;
+	}
+
+	static void geoWithHttpLookup(String ocwcGeoSource, String ocwcGeoTarget,
+			String targetPath) throws URISyntaxException {
+		final DirReader dirReader = new DirReader();
+		final FileOpener opener = new FileOpener();
+		final JsonDecoder jsonDecoder = new JsonDecoder();
+		final JsonDecoder jsonDecoder1 = new JsonDecoder();
+		final Metamorph morphGeo = new Metamorph(Thread.currentThread()
+				.getContextClassLoader()
+				.getResource("morph-ocwConsortiumMembers-buildGeoOsmUrl.xml")
+				.getFile());
+		final Metamorph morphOSM = new Metamorph(Thread.currentThread()
+				.getContextClassLoader()
+				.getResource("morph-ocwConsortiumMembers-osm.xml").getFile());
+		final PipeEncodeTriples geoEncoder = new PipeEncodeTriples();
+		geoEncoder.setStoreUrnAsUri("true");
+		final Triples2RdfModel triple2modelGeo = new Triples2RdfModel();
+		final RdfModelFileWriter geoWriter = createWriter(targetPath
+				+ ocwcGeoTarget);
+		final StreamTee streamTee = new StreamTee();
+		final Stats stats = new Stats();
+		streamTee.addReceiver(stats);
+		final HttpOpener httpOpener = new HttpOpener();
+		httpOpener.setReceiver(jsonDecoder1);
+		jsonDecoder1.setReceiver(morphOSM);
+		morphOSM.setReceiver(geoEncoder);
+		geoEncoder.setReceiver(triple2modelGeo);
+		triple2modelGeo.setReceiver(geoWriter);
+		final LiteralExtractor literalExtractor = new LiteralExtractor();
+		streamTee.addReceiver(literalExtractor);//
+		literalExtractor.setReceiver(httpOpener);
+		opener.setReceiver(jsonDecoder);
+		jsonDecoder.setReceiver(morphGeo).setReceiver(streamTee);
+		dirReader.setReceiver(opener);
+		dirReader.process((new File(Thread.currentThread()
+				.getContextClassLoader().getResource(ocwcGeoSource).toURI()))
+				.getAbsolutePath());
+		opener.closeStream();
+	}
+
+	private static RdfModelFileWriter createWriter(final String PATH) {
+		final RdfModelFileWriter writer = new RdfModelFileWriter();
+		writer.setProperty("http://purl.org/dc/elements/1.1/identifier");
+		writer.setEndIndex(1);
+		writer.setStartIndex(0);
+		writer.setFileSuffix("nt");
+		writer.setSerialization("N-TRIPLE");
+		writer.setTarget(PATH);
+		return writer;
+	}
+
+}

--- a/oer-data/src/test/java/org/hbz/oerworldmap/EnrichmentViaGeoCoordinatesHttpLookupTest.java
+++ b/oer-data/src/test/java/org/hbz/oerworldmap/EnrichmentViaGeoCoordinatesHttpLookupTest.java
@@ -7,18 +7,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 
 import org.apache.commons.io.FileUtils;
-import org.culturegraph.mf.morph.Metamorph;
-import org.culturegraph.mf.stream.converter.LiteralExtractor;
-import org.culturegraph.mf.stream.pipe.StreamTee;
-import org.culturegraph.mf.stream.source.DirReader;
-import org.culturegraph.mf.stream.source.FileOpener;
-import org.culturegraph.mf.stream.source.HttpOpener;
 import org.junit.Test;
 import org.lobid.lodmill.AbstractIngestTests;
-import org.lobid.lodmill.PipeEncodeTriples;
-import org.lobid.lodmill.RdfModelFileWriter;
-import org.lobid.lodmill.Stats;
-import org.lobid.lodmill.Triples2RdfModel;
 
 /**
  * @author Pascal Christoph (dr0i)
@@ -28,67 +18,28 @@ import org.lobid.lodmill.Triples2RdfModel;
 public class EnrichmentViaGeoCoordinatesHttpLookupTest {
 	private static final String OCWC_GEO_SOURCE = "ocwc/small/geoList";
 	private static final String OCWC_GEO_TARGET = "ocwc/small/geo";
-	// uncomment for transforming the whole data
-	// private static final String OCWC_GEO_LIST = "ocwc/geoList";
 	private static final String TARGET_PATH = "tmp/";
+
 	private final String OCWC_PATH = "ocwc/";
 	private final String TEST_FILENAME = "geoOsmTestResult.nt";
 
 	@Test
 	public void transformDataInDirectory() throws URISyntaxException {
 		FileUtils.deleteQuietly(new File(TARGET_PATH));
-		final DirReader dirReader = new DirReader();
-		final FileOpener opener = new FileOpener();
-		final JsonDecoder jsonDecoder = new JsonDecoder();
-		final JsonDecoder jsonDecoder1 = new JsonDecoder();
-		final Metamorph morphGeo = new Metamorph(Thread.currentThread().getContextClassLoader()
-				.getResource("morph-ocwConsortiumMembers-buildGeoOsmUrl.xml").getFile());
-		final Metamorph morphOSM = new Metamorph(Thread.currentThread().getContextClassLoader()
-				.getResource("morph-ocwConsortiumMembers-osm.xml").getFile());
-		final PipeEncodeTriples geoEncoder = new PipeEncodeTriples();
-		geoEncoder.setStoreUrnAsUri("true");
-		final Triples2RdfModel triple2modelGeo = new Triples2RdfModel();
-		final RdfModelFileWriter geoWriter = createWriter(TARGET_PATH + OCWC_GEO_TARGET);
-		final StreamTee streamTee = new StreamTee();
-		final Stats stats = new Stats();
-		streamTee.addReceiver(stats);
-		final HttpOpener httpOpener = new HttpOpener();
-		httpOpener.setReceiver(jsonDecoder1);
-		jsonDecoder1.setReceiver(morphOSM);
-		morphOSM.setReceiver(geoEncoder);
-		geoEncoder.setReceiver(triple2modelGeo);
-		triple2modelGeo.setReceiver(geoWriter);
-		final LiteralExtractor literalExtractor = new LiteralExtractor();
-		streamTee.addReceiver(literalExtractor);//
-		literalExtractor.setReceiver(httpOpener);
-		opener.setReceiver(jsonDecoder);
-		jsonDecoder.setReceiver(morphGeo).setReceiver(streamTee);
-		dirReader.setReceiver(opener);
-		dirReader.process((new File(Thread.currentThread().getContextClassLoader()
-				.getResource(OCWC_GEO_SOURCE).toURI())).getAbsolutePath());
-		opener.closeStream();
+		Transform.geoWithHttpLookup(OCWC_GEO_SOURCE, OCWC_GEO_TARGET,
+				TARGET_PATH);
 		try {
 			File testFile;
-
-			testFile = AbstractIngestTests.concatenateGeneratedFilesIntoOneFile(TARGET_PATH,
-					TARGET_PATH + OCWC_PATH + TEST_FILENAME);
-			AbstractIngestTests.compareFilesDefaultingBNodes(testFile, new File(Thread
-					.currentThread().getContextClassLoader().getResource(OCWC_PATH + TEST_FILENAME)
-					.toURI()));
+			testFile = AbstractIngestTests
+					.concatenateGeneratedFilesIntoOneFile(TARGET_PATH,
+							TARGET_PATH + OCWC_PATH + TEST_FILENAME);
+			AbstractIngestTests.compareFilesDefaultingBNodes(testFile,
+					new File(Thread.currentThread().getContextClassLoader()
+							.getResource(OCWC_PATH + TEST_FILENAME).toURI()));
 			FileUtils.deleteDirectory(new File(TARGET_PATH));
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
 	}
 
-	private static RdfModelFileWriter createWriter(final String PATH) {
-		final RdfModelFileWriter writer = new RdfModelFileWriter();
-		writer.setProperty("http://purl.org/dc/elements/1.1/identifier");
-		writer.setEndIndex(1);
-		writer.setStartIndex(0);
-		writer.setFileSuffix("nt");
-		writer.setSerialization("N-TRIPLE");
-		writer.setTarget(PATH);
-		return writer;
-	}
 }

--- a/oer-data/src/test/java/org/hbz/oerworldmap/OerJson2RdfWriterTest.java
+++ b/oer-data/src/test/java/org/hbz/oerworldmap/OerJson2RdfWriterTest.java
@@ -8,16 +8,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 
 import org.apache.commons.io.FileUtils;
-import org.culturegraph.mf.morph.Metamorph;
-import org.culturegraph.mf.stream.pipe.StreamTee;
-import org.culturegraph.mf.stream.source.DirReader;
-import org.culturegraph.mf.stream.source.FileOpener;
 import org.junit.Test;
 import org.lobid.lodmill.AbstractIngestTests;
-import org.lobid.lodmill.PipeEncodeTriples;
-import org.lobid.lodmill.RdfModelFileWriter;
-import org.lobid.lodmill.Stats;
-import org.lobid.lodmill.Triples2RdfModel;
 
 /**
  * @author Pascal Christoph (dr0i)
@@ -28,38 +20,26 @@ public class OerJson2RdfWriterTest {
 	private static final String GEO_LIST = "small/geoList";
 	private static final String ORGANIZATION_ID = "small/organizationId";
 	private static final String CONSORTIUM_MEMBERS = "small/consortiumMembers";
-	// uncomment for transforming the whole data
-	// private static final String GEO_LIST = "geoList";
-	// private static final String ORGANIZATION_ID = "organizationId";
-	// private static final String CONSORTIUM_MEMBERS = "consortiumMembers";
+
 	private final String OCWC_PATH = "ocwc/";
 	private final String TARGET_PATH = "tmp/";
 	private final String TEST_FILENAME = "ocwcTestResult.nt";
-
-	private static RdfModelFileWriter createWriter(final String PATH) {
-		final RdfModelFileWriter writer = new RdfModelFileWriter();
-		writer.setProperty("http://purl.org/dc/elements/1.1/identifier");
-		writer.setEndIndex(1);
-		writer.setStartIndex(0);
-		writer.setFileSuffix("nt");
-		writer.setSerialization("N-TRIPLE");
-		writer.setTarget(PATH);
-		return writer;
-	}
 
 	@Test
 	public void testFlow() {
 		try {
 			FileUtils.deleteQuietly(new File(TARGET_PATH));
-			transformDataInDirectory(OCWC_PATH + CONSORTIUM_MEMBERS);
-			transformDataInDirectory(OCWC_PATH + ORGANIZATION_ID);
-			transformDataInDirectory(OCWC_PATH + GEO_LIST);
+			Transform.dataInDirectory(TARGET_PATH, OCWC_PATH
+					+ CONSORTIUM_MEMBERS);
+			Transform.dataInDirectory(TARGET_PATH, OCWC_PATH + ORGANIZATION_ID);
+			Transform.dataInDirectory(TARGET_PATH, OCWC_PATH + GEO_LIST);
 			File testFile;
-			testFile = AbstractIngestTests.concatenateGeneratedFilesIntoOneFile(TARGET_PATH,
-					TARGET_PATH + OCWC_PATH + TEST_FILENAME);
-			AbstractIngestTests.compareFilesDefaultingBNodes(testFile, new File(Thread
-					.currentThread().getContextClassLoader().getResource(OCWC_PATH + TEST_FILENAME)
-					.toURI()));
+			testFile = AbstractIngestTests
+					.concatenateGeneratedFilesIntoOneFile(TARGET_PATH,
+							TARGET_PATH + OCWC_PATH + TEST_FILENAME);
+			AbstractIngestTests.compareFilesDefaultingBNodes(testFile,
+					new File(Thread.currentThread().getContextClassLoader()
+							.getResource(OCWC_PATH + TEST_FILENAME).toURI()));
 			FileUtils.deleteDirectory(new File(TARGET_PATH));
 		} catch (final FileNotFoundException e) {
 			e.printStackTrace();
@@ -68,31 +48,5 @@ public class OerJson2RdfWriterTest {
 		} catch (URISyntaxException e) {
 			e.printStackTrace();
 		}
-	}
-
-	private void transformDataInDirectory(final String pathToDirectory) throws URISyntaxException {
-		final DirReader dirReader = new DirReader();
-		final FileOpener opener = new FileOpener();
-		final JsonDecoder jsonDecoder = new JsonDecoder();
-		final Metamorph morph = new Metamorph(Thread.currentThread().getContextClassLoader()
-				.getResource("morph-ocwConsortiumMembers-to-rdf.xml").getFile());
-		final PipeEncodeTriples encoder = new PipeEncodeTriples();
-		encoder.setStoreUrnAsUri("true");
-		final Triples2RdfModel triple2model = new Triples2RdfModel();
-		triple2model.setInput("N-TRIPLE");
-		final RdfModelFileWriter writer = OerJson2RdfWriterTest.createWriter(TARGET_PATH
-				+ pathToDirectory);
-		final StreamTee streamTee = new StreamTee();
-		final Stats stats = new Stats();
-		streamTee.addReceiver(stats);
-		streamTee.addReceiver(encoder);
-		encoder.setReceiver(triple2model).setReceiver(writer);
-		opener.setReceiver(jsonDecoder);
-		jsonDecoder.setReceiver(morph).setReceiver(streamTee);
-		dirReader.setReceiver(opener);
-		dirReader.process((new File(Thread.currentThread().getContextClassLoader()
-				.getResource(pathToDirectory).toURI())).getAbsolutePath());
-		opener.closeStream();
-
 	}
 }


### PR DESCRIPTION
See #5.

Move the actual transformation code into a Transform class, call that from the tests. Add a main method to do the actual full transformation (run Transform.java as Java application).

Run NtToEs.java in oer-api to index the result in Elasticsearch.

<!---
@huboard:{"order":0.609375,"custom_state":""}
-->
